### PR TITLE
Add 'url' schema to polling_source resource for SNS notifications

### DIFF
--- a/sumologic/resource_sumologic_polling_source.go
+++ b/sumologic/resource_sumologic_polling_source.go
@@ -30,6 +30,12 @@ func resourceSumologicPollingSource() *schema.Resource {
 		Required: true,
 		ForceNew: false,
 	}
+	pollingSource.Schema["url"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: false,
+		ForceNew: false,
+		Computed: true,
+	}
 	pollingSource.Schema["authentication"] = &schema.Schema{
 		Type:     schema.TypeList,
 		Required: true,
@@ -155,6 +161,7 @@ func resourceSumologicPollingSourceRead(d *schema.ResourceData, meta interface{}
 	d.Set("content_type", source.ContentType)
 	d.Set("scan_interval", source.ScanInterval)
 	d.Set("paused", source.Paused)
+	d.Set("url", source.URL)
 
 	return nil
 }
@@ -168,6 +175,7 @@ func resourceToPollingSource(d *schema.ResourceData) PollingSource {
 		Paused:       d.Get("paused").(bool),
 		ScanInterval: d.Get("scan_interval").(int),
 		ContentType:  d.Get("content_type").(string),
+		URL:          d.Get("url").(string),
 	}
 
 	pollingResource := PollingResource{

--- a/sumologic/sumologic_polling_source.go
+++ b/sumologic/sumologic_polling_source.go
@@ -10,6 +10,7 @@ type PollingSource struct {
 	ContentType   string               `json:"contentType"`
 	ScanInterval  int                  `json:"scanInterval"`
 	Paused        bool                 `json:"paused"`
+	URL           bool                 `json:"url"`
 	ThirdPartyRef PollingThirdPartyRef `json:"thirdPartyRef,omitempty"`
 }
 


### PR DESCRIPTION
Adding this schema allows for the computed URL of the polling_source resource to be used as a SNS topic subscription https endpoint.