### PR TITLE
issue-11 terraform data source for sumo collector

### DIFF
--- a/docs/d/sumologic_collector.md
+++ b/docs/d/sumologic_collector.md
@@ -1,0 +1,36 @@
+# sumologic_collector
+
+Provides a way to retrieve Sumo Logic collector details (id, names, etc) for a collector
+managed by another terraform stack.
+
+
+## Example Usage
+```hcl
+data "sumologic_collector" "this" {
+  name = "MyCollector"
+}
+```
+
+```hcl
+data "sumologic_collector" "that" {
+  id = "1234567890"
+}
+```
+
+A collector can be looked up by either `id` or `name`. One of those attributes needs to be specified.
+
+If both `id` and `name` have been specified, `id` takes precedence.
+
+## Attributes reference
+The following attributes are exported:
+- `id` - The internal ID of the collector. This can be used to attach sources to the collector.
+- `name` - The name of the collector.
+- `description` - The description of the collector.
+- `category` - The default source category for any source attached to this collector.
+- `timezone` - The time zone to use for this collector. The value follows the [tzdata][2] naming convention.
+
+
+[Back to Index][0]
+
+[0]: ../README.md
+

--- a/sumologic/data_source_sumologic_collector.go
+++ b/sumologic/data_source_sumologic_collector.go
@@ -1,0 +1,77 @@
+package sumologic
+
+import (
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strconv"
+)
+
+func dataSourceSumologicCollector() *schema.Resource {
+	return &schema.Resource{
+		Read:   dataSourceSumologicCollectorRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"timezone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSumologicCollectorRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	var collector *Collector
+	var err error
+	if cid, ok := d.GetOk("id"); ok {
+		id := cid.(int)
+		collector, err = c.GetCollector(id)
+		if err != nil {
+			return fmt.Errorf("collector with id %d not found: %v", id, err)
+		}
+	} else {
+		if cname, ok := d.GetOk("name"); ok {
+			name := cname.(string)
+			collector, err = c.GetCollectorName(name)
+			if err != nil {
+				return fmt.Errorf("collector with name %s not found: %v", name, err)
+			}
+			if collector == nil {
+				return fmt.Errorf("collector with name %s not found", name)
+			}
+		} else {
+			return errors.New("please specify either id or name")
+		}
+	}
+
+	d.SetId(strconv.Itoa(collector.ID))
+	d.Set("name", collector.Name)
+	d.Set("description", collector.Description)
+	d.Set("category", collector.Category)
+	d.Set("timezone", collector.TimeZone)
+
+	log.Printf("[DEBUG] data_source_sumologic_collector: retrieved %v", collector)
+	return nil
+}
+

--- a/sumologic/data_source_sumologic_collector_test.go
+++ b/sumologic/data_source_sumologic_collector_test.go
@@ -1,0 +1,50 @@
+package sumologic
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourcSumologicCollector(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAccSumologicCollectorConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceCollectorCheck("data.sumologic_collector.by_name", "sumologic_collector.test"),
+					testAccDataSourceCollectorCheck("data.sumologic_collector.by_id", "sumologic_collector.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCollectorCheck(name, reference string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttrSet(name, "id"),
+		resource.TestCheckResourceAttrPair(name, "id", reference, "id"),
+		resource.TestCheckResourceAttrPair(name, "name", reference, "name"),
+		resource.TestCheckResourceAttrPair(name, "description", reference, "description"),
+		resource.TestCheckResourceAttrPair(name, "category", reference, "category"),
+		resource.TestCheckResourceAttrPair(name, "timezone", reference, "timezone"),
+	)
+}
+
+var testDataSourceAccSumologicCollectorConfig = `
+resource "sumologic_collector" "test" {
+  name = "MyCollector"
+  description = "MyCollectorDesc"
+  category = "Cat"
+  timezone = "Europe/Berlin"
+}
+
+data "sumologic_collector" "by_name" {
+  name = "${sumologic_collector.test.name}"
+}
+
+data "sumologic_collector" "by_id" {
+  id = "${sumologic_collector.test.id}"
+}
+`

--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -42,6 +42,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"sumologic_caller_identity": dataSourceSumologicCallerIdentity(),
+			"sumologic_collector":       dataSourceSumologicCollector(),
 		},
 		ConfigureFunc: providerConfigure,
 	}


### PR DESCRIPTION
new terraform data source for SumoLogic collectors.
the acceptance test for the new data source currently fails on the test tear-down because of an issue in the collector resource; the test will fix itself once that issue with the collector resource is fixed