### PR TITLE
Add import support for http sources

### DIFF
--- a/docs/r/sumologic_http_source.md
+++ b/docs/r/sumologic_http_source.md
@@ -28,6 +28,13 @@ The following attributes are exported:
 - `id` - The internal ID of the source.
 - `url` - The HTTP endpoint to use for sending data to this source.
 
+## Import
+HTTP sources can be imported using the collector and source IDs (`collector/source`), e.g.:
+
+```hcl
+terraform import sumologic_http_collector.test 123/456
+```
+
 [Back to Index][0]
 
 [0]: ../README.md

--- a/sumologic/resource_sumologic_http_source.go
+++ b/sumologic/resource_sumologic_http_source.go
@@ -12,6 +12,9 @@ func resourceSumologicHTTPSource() *schema.Resource {
 	httpSource.Create = resourceSumologicHTTPSourceCreate
 	httpSource.Read = resourceSumologicHTTPSourceRead
 	httpSource.Update = resourceSumologicHTTPSourceUpdate
+	httpSource.Importer = &schema.ResourceImporter{
+		State: resourceSumologicSourceImport,
+	}
 
 	httpSource.Schema["message_per_request"] = &schema.Schema{
 		Type:     schema.TypeBool,

--- a/sumologic/resource_sumologic_http_source_test.go
+++ b/sumologic/resource_sumologic_http_source_test.go
@@ -58,6 +58,7 @@ func TestAccSumologicHTTPSourceImport(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:            testAccSumologicHTTPSourceConfig,
+				ResourceName:      "sumologic_http_source.http",
 				ImportState:       true,
 				ImportStateId:     "123/456",
 				ImportStateVerify: true,

--- a/sumologic/resource_sumologic_http_source_test.go
+++ b/sumologic/resource_sumologic_http_source_test.go
@@ -52,6 +52,25 @@ func TestAccSumologicHTTPSourceUpdate(t *testing.T) {
 	})
 }
 
+func TestAccSumologicHTTPSourceImport(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccSumologicHTTPSourceConfig,
+				ImportState:       true,
+				ImportStateId:     "123/456",
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHTTPSourceExists("sumologic_http_source.http", t),
+					resource.TestCheckResourceAttr("sumologic_http_source.http", "id", "123"),
+					resource.TestCheckResourceAttr("sumologic_http_source.http", "collector_id", "456"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckHTTPSourceExists(n string, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return nil

--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -194,6 +195,17 @@ func resourceSumologicSourceDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	return nil
+}
+
+func resourceSumologicSourceImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	ids := strings.Split(d.Id(), "/")
+
+	d.SetId(ids[1])
+
+	collectorID, _ := strconv.Atoi(ids[0])
+	d.Set("collector_id", collectorID)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceToSource(d *schema.ResourceData) Source {

--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -200,6 +200,10 @@ func resourceSumologicSourceDelete(d *schema.ResourceData, meta interface{}) err
 func resourceSumologicSourceImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	ids := strings.Split(d.Id(), "/")
 
+	if len(ids) != 2 {
+		return errors.Sprintf("expected collector_id/source_id, got %s", d.Id())
+	}
+
 	d.SetId(ids[1])
 
 	collectorID, _ := strconv.Atoi(ids[0])

--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -201,7 +201,7 @@ func resourceSumologicSourceImport(d *schema.ResourceData, m interface{}) ([]*sc
 	ids := strings.Split(d.Id(), "/")
 
 	if len(ids) != 2 {
-		return errors.Sprintf("expected collector_id/source_id, got %s", d.Id())
+		return nil, fmt.Errorf("expected collector_id/source_id, got %s", d.Id())
 	}
 
 	d.SetId(ids[1])


### PR DESCRIPTION
This provides the initial work for supporting import of HTTP source. Unlikely collectors, an ID-only passthrough import is not possible. Instead I elected to do `terraform import sumologic_http_source.<name> <collector_id>/<source_id>` and split on the `/` in order to populate the 2 required IDs. 

Still todo:

* Add some extra validation, e.g. ensuring 2 IDs are passed
* Add tests against that
* Add importers to other comparable resources

I was able to build this and use it to quickly import something so I figured I'd open the PR until I have a chance to finish it up