### PR TITLE
fix random order issue of string list

### DIFF
--- a/sumologic/resource_sumologic_role.go
+++ b/sumologic/resource_sumologic_role.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"log"
+	"sort"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -87,7 +88,9 @@ func resourceSumologicRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", role.Name)
 	d.Set("description", role.Description)
 	d.Set("filter_predicate", role.FilterPredicate)
+	sort.Strings(role.Users)
 	d.Set("users", role.Users)
+	sort.Strings(role.Capabilities)
 	d.Set("capabilities", role.Capabilities)
 
 	return nil


### PR DESCRIPTION
When `users` or `capabilities` has multiple value, it cause diff always...

@frankreno Sorry, I didn't notice this issue when I test.
