### PR TITLE
docs: fix typo in http_source import example

### DIFF
--- a/docs/r/sumologic_http_source.md
+++ b/docs/r/sumologic_http_source.md
@@ -32,7 +32,7 @@ The following attributes are exported:
 HTTP sources can be imported using the collector and source IDs (`collector/source`), e.g.:
 
 ```hcl
-terraform import sumologic_http_collector.test 123/456
+terraform import sumologic_http_source.test 123/456
 ```
 
 [Back to Index][0]


### PR DESCRIPTION
Closes #45