### PR TITLE
Corrects the JSON tag for cloud syslog token

### DIFF
--- a/sumologic/sumologic_cloudsyslog_source.go
+++ b/sumologic/sumologic_cloudsyslog_source.go
@@ -7,7 +7,7 @@ import (
 
 type CloudSyslogSource struct {
 	Source
-	Token string `json:"url,omitempty"`
+	Token string `json:"token,omitempty"`
 }
 
 func (s *Client) CreateCloudsyslogSource(cloudSyslogSource CloudSyslogSource, collectorID int) (int, error) {


### PR DESCRIPTION
The cloud syslog token was perviously always empty because the token is returned from the API on the `token` key. 