### PR TITLE
docs: remove message_per_request from http_source example

### DIFF
--- a/docs/r/sumologic_http_source.md
+++ b/docs/r/sumologic_http_source.md
@@ -8,7 +8,6 @@ __IMPORTANT:__ The endpoint is stored in plain-text in the state. This is a pote
 resource "sumologic_http_source" "http_source" {
   name                = "HTTP"
   description         = "My description"
-  message_per_request = true
   category            = "my/source/category"
   collector_id        = "${sumologic_collector.collector.id}"
 }


### PR DESCRIPTION
Doesn't seem like a good default to be suggesting by example

Closes #35