### PR TITLE
Adding folder management plugin for terraform provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/SumoLogic/sumologic-terraform-provider.svg?branch=master)](https://travis-ci.org/SumoLogic/sumologic-terraform-provider) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/SumoLogic/sumologic-terraform-provider/issues)
+[![Build Status](https://travis-ci.org/sumologic/sumologic-terraform-provider.svg?branch=master)](https://travis-ci.org/sumologic/sumologic-terraform-provider) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/sumologic/sumologic-terraform-provider/issues)
 
 # terraform-provider-sumologic
 This provider is used to manage Hosted collectors and sources supported by Sumo Logic.

--- a/docs/r/sumologic_folder.md
+++ b/docs/r/sumologic_folder.md
@@ -1,0 +1,28 @@
+# sumologic_folder
+Provides the ability to create, read, delete, update, and manage of folders.
+
+## Example Usage
+```hcl
+resource "sumologic_folder" "folder" {
+  name        = "test-folder"
+  description = "Just testing this"
+  parent_id   = "<Hexadecimal ID of the parent folder>"
+}
+```
+
+## Argument reference
+The following arguments are supported:
+- `name` - (Required) The name of the folder. This is required, and has to be unique.
+- `parent_id` - (Required) The ID of the folder in which you want to create the new folder.
+- `description` - (Optional) The description of the folder.
+
+## Additional data provided in state
+- `created_at` - (Computed) When the folder was created.
+- `created_by` - (Computed) Who created the folder.
+- `modified_at` - (Computed) When was the folder last modified.
+- `modified_by` - (Computed) The ID of the user who modified the folder last.
+- `item_type` - (Computed) What the type of the content item is (will obviously be "Folder").
+- `permissions` - (Computed) List of permissions the user has on the content item.
+- `children` - (Computed) A list of all the content items in the created folder (can be folders or other content items).
+
+[Back to Index][0]

--- a/docs/r/sumologic_folder.md
+++ b/docs/r/sumologic_folder.md
@@ -10,6 +10,11 @@ resource "sumologic_folder" "folder" {
 }
 ```
 
+## Finding the parent ID
+Unfortunately, the only way to find the parent folder's hexadecimal ID is by sending the following request `curl -X GET -u {ACCESS_ID}:{ACCESS_KEY} https://api.sumologic.com/api/v2/content/folders/personal` and subsequently getting children's folders (GET `.../api/v2/content/folders/{id}`) until you find the correct parent folder.
+
+In the future, there will be a button in the UI that will reveal the hex ID.
+
 ## Argument reference
 The following arguments are supported:
 - `name` - (Required) The name of the folder. This is required, and has to be unique.

--- a/docs/r/sumologic_folder.md
+++ b/docs/r/sumologic_folder.md
@@ -24,5 +24,3 @@ The following arguments are supported:
 - `item_type` - (Computed) What the type of the content item is (will obviously be "Folder").
 - `permissions` - (Computed) List of permissions the user has on the content item.
 - `children` - (Computed) A list of all the content items in the created folder (can be folders or other content items).
-
-[Back to Index][0]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/SumoLogic/sumologic-terraform-provider
+module github.com/sumologic/sumologic-terraform-provider
 
 go 1.12
 

--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -38,7 +38,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_user":                               resourceSumologicUser(),
 			"sumologic_ingest_budget":                      resourceSumologicIngestBudget(),
 			"sumologic_collector_ingest_budget_assignment": resourceSumologicCollectorIngestBudgetAssignment(),
-			"sumologic_folder": resourceSumologicFolder(),
+			"sumologic_folder":				resourceSumologicFolder(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"sumologic_caller_identity": dataSourceSumologicCallerIdentity(),

--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -3,7 +3,6 @@ package sumologic
 import (
 	"fmt"
 	"github.com/go-errors/errors"
-	"log"
 	"os"
 
 	"github.com/hashicorp/terraform/helper/mutexkv"
@@ -11,15 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-const DefaultEnvironment = "us2"
-
 func Provider() terraform.ResourceProvider {
-	defaultEnvironment := os.Getenv("SUMOLOGIC_ENVIRONMENT")
-	if defaultEnvironment == "" {
-		defaultEnvironment = DefaultEnvironment
-	}
-	log.Printf("[DEBUG] sumo default environment: %s", defaultEnvironment)
-
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"access_id": {
@@ -35,7 +26,7 @@ func Provider() terraform.ResourceProvider {
 			"environment": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  defaultEnvironment,
+				Default:  os.Getenv("SUMOLOGIC_ENVIRONMENT"),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -47,6 +38,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_user":                               resourceSumologicUser(),
 			"sumologic_ingest_budget":                      resourceSumologicIngestBudget(),
 			"sumologic_collector_ingest_budget_assignment": resourceSumologicCollectorIngestBudgetAssignment(),
+			"sumologic_folder": resourceSumologicFolder(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"sumologic_caller_identity": dataSourceSumologicCallerIdentity(),
@@ -71,8 +63,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		msg = fmt.Sprintf("%s access_key should be set; ", msg)
 	}
 	if msg != "" {
-		if environment == DefaultEnvironment {
-			msg = fmt.Sprintf("%s make sure environment is set or that the default (%s) is appropriate", msg, DefaultEnvironment)
+		if environment == "" {
+			msg = fmt.Sprintf("%s make sure environment is set", msg)
 		}
 		return nil, errors.New(msg)
 	}

--- a/sumologic/resource_sumologic_folder.go
+++ b/sumologic/resource_sumologic_folder.go
@@ -64,7 +64,7 @@ func resourceSumologicFolder() *schema.Resource {
 						},
 						"description": {
 							Type: schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 						"parent_id": {
 							Type: schema.TypeString,

--- a/sumologic/resource_sumologic_folder.go
+++ b/sumologic/resource_sumologic_folder.go
@@ -64,7 +64,7 @@ func resourceSumologicFolder() *schema.Resource {
 						},
 						"description": {
 							Type: schema.TypeString,
-							Optional: true,
+							Required: true,
 						},
 						"parent_id": {
 							Type: schema.TypeString,

--- a/sumologic/resource_sumologic_folder.go
+++ b/sumologic/resource_sumologic_folder.go
@@ -1,0 +1,204 @@
+package sumologic
+
+import (
+	"time"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceSumologicFolder() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSumologicFolderCreate,
+		Read: resourceSumologicFolderRead,
+		Update: resourceSumologicFolderUpdate,
+		Delete: resourceSumologicFolderDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type: schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type: schema.TypeString,
+				Optional: true,
+				Default: "",
+			},
+			"parent_id": {
+				Type: schema.TypeString,
+				Required: true,
+			},
+			"created_at": {
+				Type: schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type: schema.TypeString,
+				Computed: true,
+			},
+			"modified_at": {
+				Type: schema.TypeString,
+				Computed: true,
+			},
+			"modified_by": {
+				Type: schema.TypeString,
+				Computed: true,
+			},
+			"item_type": {
+				Type: schema.TypeString,
+				Computed: true,
+			},
+			"permissions": {
+				Type: schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"children": {
+				Type: schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type: schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type: schema.TypeString,
+							Required: true,
+						},
+						"parent_id": {
+							Type: schema.TypeString,
+							Required: true,
+						},
+						"created_at": {
+							Type: schema.TypeString,
+							Computed: true,
+						},
+						"created_by": {
+							Type: schema.TypeString,
+							Computed: true,
+						},
+						"modified_at": {
+							Type: schema.TypeString,
+							Computed: true,
+						},
+						"modified_by": {
+							Type: schema.TypeString,
+							Computed: true,
+						},
+						"item_type": {
+							Type: schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type: schema.TypeString,
+							Computed: true,
+						},
+						"permissions": {
+							Type: schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceSumologicFolderCreate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	folder_name := d.Get("name").(string)
+	folder_description := d.Get("description").(string)
+	folder_parent := d.Get("parent_id").(string)
+	folder := FolderCreate{}
+	folder.Name = folder_name
+	folder.Description = folder_description
+	folder.ParentId = folder_parent
+	folderResponse, err := c.CreateFolder(folder)
+	if err != nil {
+		return err
+	}
+	d.SetId(folderResponse.ID)
+	resourceSumologicFolderSetAttr(d, folderResponse)
+	return nil
+}
+
+func resourceSumologicFolderRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	folder, err := c.GetFolder(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceSumologicFolderSetAttr(d, folder)
+	return nil
+}
+
+func resourceSumologicFolderSetAttr(d *schema.ResourceData, folder Folder) {
+	d.Set("name", folder.Name)
+	d.Set("description", folder.Description)
+	d.Set("parent_id", folder.ParentId)
+	d.Set("created_at", folder.CreatedAt)
+	d.Set("created_by", folder.CreatedBy)
+	d.Set("modified_at", folder.ModifiedAt)
+	d.Set("modified_by", folder.ModifiedBy)
+	d.Set("item_type", folder.ItemType)
+	d.Set("permissions", folder.Permissions)
+	children := make([]map[string]interface{}, len(folder.Children), len(folder.Children))
+	for idx, folder_child := range folder.Children {
+		child := make(map[string]interface{})
+		child["name"] = folder_child.Name
+		child["description"] = folder_child.Description
+		child["parent_id"] = folder_child.ParentId
+		child["item_type"] = folder_child.ItemType
+		child["permissions"] = folder_child.Permissions
+		child["created_at"] = folder_child.CreatedAt
+		child["created_by"] = folder_child.CreatedBy
+		child["modified_at"] = folder_child.ModifiedAt
+		child["modified_by"] = folder_child.ModifiedBy
+		child["id"] = folder_child.ID
+		children[idx] = child
+	}
+	d.Set("children", children)
+}
+
+func resourceSumologicFolderUpdate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	folder_name := d.Get("name").(string)
+	folder_description := d.Get("description").(string)
+	folder := FolderUpdate{}
+	folder.Name = folder_name
+	folder.Description = folder_description
+	folderResponse, err := c.UpdateFolder(d.Id(), folder)
+	if err != nil {
+		return err
+	}
+	resourceSumologicFolderSetAttr(d, folderResponse)
+	return nil
+}
+
+func resourceSumologicFolderDelete(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+	job_id, err := c.StartDeleteFolder(d.Id())
+	if err != nil {
+		return err
+	}
+	job_finished := false
+	for !job_finished {
+		time.Sleep(time.Second)
+		status, err := c.DeleteFolderStatus(d.Id(), job_id)
+		if err != nil {
+			return nil
+		}
+		if status == "Success" {
+			job_finished = true
+		}
+	}
+	d.SetId("")
+	return nil
+}

--- a/sumologic/resource_sumologic_folder_test.go
+++ b/sumologic/resource_sumologic_folder_test.go
@@ -1,0 +1,110 @@
+package sumologic
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccFolder(t *testing.T) {
+	var folder Folder
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {testAccPreCheck(t)},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFolderDestroy(folder),
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccSumologicFolder,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFolderExists("sumologic_folder.test", &folder, t),
+					testAccCheckFolderAttributes("sumologic_folder.test"),
+					resource.TestCheckResourceAttr("sumologic_folder.test", "description", ""),
+				),
+			},
+			{
+				Config: TestAccSumologicFolderUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFolderExists("sumologic_folder.test", &folder, t),
+					testAccCheckFolderAttributes("sumologic_folder.test"),
+					resource.TestCheckResourceAttr("sumologic_folder.test", "description", "Update test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFolderExists(name string, folder *Folder, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Folder not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Folder ID is not set")
+		}
+
+		id := rs.Primary.ID
+		c := testAccProvider.Meta().(*Client)
+		newFolder, err := c.GetFolder(id)
+		if err != nil {
+			return fmt.Errorf("Folder %s not found", id)
+		}
+		*folder = newFolder
+		return nil
+	}
+}
+
+func testAccCheckFolderAttributes(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		f := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet(name, "name"),
+			resource.TestCheckResourceAttrSet(name, "parent_id"),
+			resource.TestCheckResourceAttrSet(name, "created_at"),
+			resource.TestCheckResourceAttrSet(name, "created_by"),
+			resource.TestCheckResourceAttrSet(name, "modified_at"),
+			resource.TestCheckResourceAttrSet(name, "modified_by"),
+			resource.TestCheckResourceAttr(name, "item_type", "Folder"),
+			resource.TestCheckResourceAttr(name, "permissions.#", "6"),
+			resource.TestCheckNoResourceAttr(name, "children.#"),
+		)
+		return f(s)
+	}
+}
+
+func testAccCheckFolderDestroy(folder Folder) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*Client)
+		_, err := client.GetFolder(folder.ID)
+		if err == nil {
+			return fmt.Errorf("Folder still exists")
+		}
+		return nil
+	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	if strings.Contains(TestAccSumologicFolder, "PERSONAL_FOLDER_HEX_ID") ||
+	strings.Contains(TestAccSumologicFolderUpdate, "PERSONAL_FOLDER_HEX_ID") {
+		t.Fatal("The parent_id must be set for the TestAccSumologicFolder and" +
+			" TestAccSumologicFolderUpdate variables")
+	}
+}
+
+var TestAccSumologicFolder = `
+resource "sumologic_folder" "test" {
+  name = "MyFolder"
+	parent_id = "<PERSONAL_FOLDER_HEX_ID>"
+}
+`
+
+var TestAccSumologicFolderUpdate = `
+resource "sumologic_folder" "test" {
+  name = "MyFolder"
+	parent_id = "<PERSONAL_FOLDER_HEX_ID>"
+	description = "Update test"
+}
+`

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -23,13 +23,13 @@ type Client struct {
 }
 
 var endpoints = map[string]string{
-	"us1": "https://api.sumologic.com/api/v1/",
-	"us2": "https://api.us2.sumologic.com/api/v1/",
-	"eu":  "https://api.eu.sumologic.com/api/v1/",
-	"au":  "https://api.au.sumologic.com/api/v1/",
-	"de":  "https://api.de.sumologic.com/api/v1/",
-	"jp":  "https://api.jp.sumologic.com/api/v1/",
-	"ca":  "https://api.ca.sumologic.com/api/v1/",
+	"us1": "https://api.sumologic.com/api/",
+	"us2": "https://api.us2.sumologic.com/api/",
+	"eu":  "https://api.eu.sumologic.com/api/",
+	"au":  "https://api.au.sumologic.com/api/",
+	"de":  "https://api.de.sumologic.com/api/",
+	"jp":  "https://api.jp.sumologic.com/api/",
+	"ca":  "https://api.ca.sumologic.com/api/",
 }
 
 var rateLimiter = time.Tick(time.Minute / 240)

--- a/sumologic/sumologic_cloudsyslog_source.go
+++ b/sumologic/sumologic_cloudsyslog_source.go
@@ -20,7 +20,7 @@ func (s *Client) CreateCloudsyslogSource(cloudSyslogSource CloudSyslogSource, co
 		Source: cloudSyslogSource,
 	}
 
-	urlPath := fmt.Sprintf("collectors/%d/sources", collectorID)
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources", collectorID)
 	body, err := s.Post(urlPath, request)
 
 	if err != nil {
@@ -40,7 +40,7 @@ func (s *Client) CreateCloudsyslogSource(cloudSyslogSource CloudSyslogSource, co
 func (s *Client) GetCloudSyslogSource(collectorID, sourceID int) (*CloudSyslogSource, error) {
 
 	body, _, err := s.Get(
-		fmt.Sprintf("collectors/%d/sources/%d", collectorID, sourceID),
+		fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, sourceID),
 	)
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func (s *Client) UpdateCloudSyslogSource(source CloudSyslogSource, collectorID i
 		Source: source,
 	}
 
-	urlPath := fmt.Sprintf("collectors/%d/sources/%d", collectorID, source.ID)
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, source.ID)
 	_, err := s.Put(urlPath, request)
 
 	return err

--- a/sumologic/sumologic_collectors.go
+++ b/sumologic/sumologic_collectors.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *Client) GetCollector(id int) (*Collector, error) {
-	data, _, err := s.Get(fmt.Sprintf("collectors/%d", id))
+	data, _, err := s.Get(fmt.Sprintf("v1/collectors/%d", id))
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func (s *Client) GetCollector(id int) (*Collector, error) {
 
 func (s *Client) GetCollectorName(name string) (*Collector, error) {
 	// TODO: check default limit count of 1000 and paginate
-	data, _, err := s.Get("collectors")
+	data, _, err := s.Get("v1/collectors")
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (s *Client) GetCollectorName(name string) (*Collector, error) {
 }
 
 func (s *Client) DeleteCollector(id int) error {
-	_, err := s.Delete(fmt.Sprintf("collectors/%d", id))
+	_, err := s.Delete(fmt.Sprintf("v1/collectors/%d", id))
 
 	return err
 }
@@ -64,7 +64,7 @@ func (s *Client) CreateCollector(collector Collector) (int, error) {
 
 	var response CollectorResponse
 
-	responseBody, err := s.Post("collectors", request)
+	responseBody, err := s.Post("v1/collectors", request)
 	if err != nil {
 		return -1, err
 	}
@@ -79,7 +79,7 @@ func (s *Client) CreateCollector(collector Collector) (int, error) {
 }
 
 func (s *Client) UpdateCollector(collector Collector) error {
-	url := fmt.Sprintf("collectors/%d", collector.ID)
+	url := fmt.Sprintf("v1/collectors/%d", collector.ID)
 
 	request := CollectorRequest{
 		Collector: collector,

--- a/sumologic/sumologic_folder.go
+++ b/sumologic/sumologic_folder.go
@@ -70,21 +70,7 @@ func (s *Client) DeleteFolderStatus(id string, job_id string) (string, error) {
 }
 
 type Folder struct {
-	Name              	string                    `json:"name"`
-	Description       	string                    `json:"description"`
-	ParentId            string                    `json:"parentId"`
-	ItemType           	string                    `json:"itemType"`
-	Permissions         []string                  `json:"permissions"`
-	CreatedAt           string                    `json:"createdAt"`
-	CreatedBy           string                    `json:"createdBy"`
-	ModifiedAt          string                    `json:"modifiedAt"`
-	ModifiedBy          string                    `json:"modifiedBy"`
-	ID              		string                    `json:"id"`
-	Children 						[]Children								`json:"children"`
-}
-
-type Children struct {
-	Name              	string                    `json:"name"`
+	Name                string                    `json:"name"`
 	Description         string                    `json:"description"`
 	ParentId            string                    `json:"parentId"`
 	ItemType            string                    `json:"itemType"`
@@ -93,32 +79,46 @@ type Children struct {
 	CreatedBy           string                    `json:"createdBy"`
 	ModifiedAt          string                    `json:"modifiedAt"`
 	ModifiedBy          string                    `json:"modifiedBy"`
-	ID              		string                    `json:"id"`
+	ID                  string                    `json:"id"`
+	Children 	    []Children		      `json:"children"`
+}
+
+type Children struct {
+	Name                string                    `json:"name"`
+	Description         string                    `json:"description"`
+	ParentId            string                    `json:"parentId"`
+	ItemType            string                    `json:"itemType"`
+	Permissions         []string                  `json:"permissions"`
+	CreatedAt           string                    `json:"createdAt"`
+	CreatedBy           string                    `json:"createdBy"`
+	ModifiedAt          string                    `json:"modifiedAt"`
+	ModifiedBy          string                    `json:"modifiedBy"`
+	ID                  string                    `json:"id"`
 }
 
 type FolderCreate struct {
-	Name              	string                    `json:"name"`
+	Name                string                    `json:"name"`
 	Description         string                    `json:"description"`
 	ParentId            string                    `json:"parentId"`
 }
 
 type FolderUpdate struct {
-	Name              	string                    `json:"name"`
+	Name                string                    `json:"name"`
 	Description         string                    `json:"description"`
 }
 
 type BeginDeletionJobResponse struct {
-	ID              		string                    `json:"id"`
+	ID                  string                    `json:"id"`
 }
 
 type DeletionJobStatus struct {
 	Status              string                    `json:"status"`
 	StatusMessage       string                    `json:"statusMessage"`
-	Error								ErrorDescription 					`json:"error"`
+	Error		    ErrorDescription 	      `json:"error"`
 }
 
 type ErrorDescription struct {
-	Code            		string                  `json:"code"`
-	Message         		string                  `json:"message"`
-	Detail          		string                  `json:"detail"`
+	Code                string                  `json:"code"`
+	Message             string                  `json:"message"`
+	Detail              string                  `json:"detail"`
 }

--- a/sumologic/sumologic_folder.go
+++ b/sumologic/sumologic_folder.go
@@ -1,0 +1,124 @@
+package sumologic
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (s *Client) CreateFolder(folder FolderCreate) (Folder, error) {
+	response, err := s.Post("v2/content/folders", folder)
+	if err != nil {
+		return Folder{}, err
+	}
+	var folderResponse Folder
+	err = json.Unmarshal(response, &folderResponse)
+	if err != nil {
+		return Folder{}, err
+	}
+	return folderResponse, nil
+}
+
+func (s *Client) GetFolder(id string) (Folder, error) {
+	var folderResponse Folder
+	response, _, err := s.Get(fmt.Sprintf("v2/content/folders/%s", id))
+	if err != nil {
+		return Folder{}, err
+	}
+
+	err = json.Unmarshal(response, &folderResponse)
+	if err != nil {
+		return Folder{}, err
+	}
+	return folderResponse, nil
+}
+
+func (s *Client) UpdateFolder(id string, folder FolderUpdate) (Folder, error) {
+	var folderResponse Folder
+	response, err := s.Put(fmt.Sprintf("v2/content/folders/%s", id), folder)
+	if err != nil {
+		return Folder{}, err
+	}
+
+	err = json.Unmarshal(response, &folderResponse)
+	if err != nil {
+		return Folder{}, err
+	}
+	return folderResponse, nil
+}
+
+func (s *Client) StartDeleteFolder(id string) (string, error) {
+	var deletionJob BeginDeletionJobResponse
+	response, err := s.Delete(fmt.Sprintf("v2/content/%s/delete", id))
+	if err != nil {
+		return "", err
+	}
+	err = json.Unmarshal(response, &deletionJob)
+	if err != nil {
+		return "", err
+	}
+	return deletionJob.ID, nil
+}
+
+func (s *Client) DeleteFolderStatus(id string, job_id string) (string, error) {
+	var deletionStatus DeletionJobStatus
+	response, _, err := s.Get(fmt.Sprintf("v2/content/%s/delete/%s/status", id, job_id))
+	err = json.Unmarshal(response, &deletionStatus)
+	if err != nil {
+		return "", err
+	}
+	return deletionStatus.Status, nil
+}
+
+type Folder struct {
+	Name              	string                    `json:"name"`
+	Description       	string                    `json:"description"`
+	ParentId            string                    `json:"parentId"`
+	ItemType           	string                    `json:"itemType"`
+	Permissions         []string                  `json:"permissions"`
+	CreatedAt           string                    `json:"createdAt"`
+	CreatedBy           string                    `json:"createdBy"`
+	ModifiedAt          string                    `json:"modifiedAt"`
+	ModifiedBy          string                    `json:"modifiedBy"`
+	ID              		string                    `json:"id"`
+	Children 						[]Children								`json:"children"`
+}
+
+type Children struct {
+	Name              	string                    `json:"name"`
+	Description         string                    `json:"description"`
+	ParentId            string                    `json:"parentId"`
+	ItemType            string                    `json:"itemType"`
+	Permissions         []string                  `json:"permissions"`
+	CreatedAt           string                    `json:"createdAt"`
+	CreatedBy           string                    `json:"createdBy"`
+	ModifiedAt          string                    `json:"modifiedAt"`
+	ModifiedBy          string                    `json:"modifiedBy"`
+	ID              		string                    `json:"id"`
+}
+
+type FolderCreate struct {
+	Name              	string                    `json:"name"`
+	Description         string                    `json:"description"`
+	ParentId            string                    `json:"parentId"`
+}
+
+type FolderUpdate struct {
+	Name              	string                    `json:"name"`
+	Description         string                    `json:"description"`
+}
+
+type BeginDeletionJobResponse struct {
+	ID              		string                    `json:"id"`
+}
+
+type DeletionJobStatus struct {
+	Status              string                    `json:"status"`
+	StatusMessage       string                    `json:"statusMessage"`
+	Error								ErrorDescription 					`json:"error"`
+}
+
+type ErrorDescription struct {
+	Code            		string                  `json:"code"`
+	Message         		string                  `json:"message"`
+	Detail          		string                  `json:"detail"`
+}

--- a/sumologic/sumologic_http_source.go
+++ b/sumologic/sumologic_http_source.go
@@ -21,7 +21,7 @@ func (s *Client) CreateHTTPSource(httpSource HTTPSource, collectorID int) (int, 
 		Source: httpSource,
 	}
 
-	urlPath := fmt.Sprintf("collectors/%d/sources", collectorID)
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources", collectorID)
 	body, err := s.Post(urlPath, request)
 
 	if err != nil {
@@ -41,7 +41,7 @@ func (s *Client) CreateHTTPSource(httpSource HTTPSource, collectorID int) (int, 
 func (s *Client) GetHTTPSource(collectorID, sourceID int) (*HTTPSource, error) {
 
 	body, _, err := s.Get(
-		fmt.Sprintf("collectors/%d/sources/%d", collectorID, sourceID),
+		fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, sourceID),
 	)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (s *Client) UpdateHTTPSource(source HTTPSource, collectorID int) error {
 		Source: source,
 	}
 
-	urlPath := fmt.Sprintf("collectors/%d/sources/%d", collectorID, source.ID)
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, source.ID)
 	_, err := s.Put(urlPath, request)
 
 	return err

--- a/sumologic/sumologic_ingest_budget.go
+++ b/sumologic/sumologic_ingest_budget.go
@@ -18,7 +18,7 @@ type IngestBudget struct {
 }
 
 func (s *Client) CreateIngestBudget(budget IngestBudget) (string, error) {
-	body, err := s.Post("ingestBudgets", budget)
+	body, err := s.Post("v1/ingestBudgets", budget)
 
 	if err != nil {
 		return "", err
@@ -36,7 +36,7 @@ func (s *Client) CreateIngestBudget(budget IngestBudget) (string, error) {
 
 func (s *Client) GetIngestBudget(id string) (*IngestBudget, error) {
 	body, _, err := s.Get(
-		fmt.Sprintf("ingestBudgets/%s", id),
+		fmt.Sprintf("v1/ingestBudgets/%s", id),
 	)
 	if err != nil {
 		return nil, err
@@ -57,14 +57,14 @@ func (s *Client) GetIngestBudget(id string) (*IngestBudget, error) {
 }
 
 func (s *Client) UpdateIngestBudget(budget IngestBudget) error {
-	urlPath := fmt.Sprintf("ingestBudgets/%s", budget.ID)
+	urlPath := fmt.Sprintf("v1/ingestBudgets/%s", budget.ID)
 	_, err := s.Put(urlPath, budget)
 
 	return err
 }
 
 func (s *Client) DeleteIngestBudget(id string) error {
-	_, err := s.Delete(fmt.Sprintf("ingestBudgets/%s", id))
+	_, err := s.Delete(fmt.Sprintf("v1/ingestBudgets/%s", id))
 
 	return err
 }
@@ -79,7 +79,7 @@ func (s *Client) FindIngestBudget(name string) (*IngestBudget, error) {
 
 	for {
 		body, _, err := s.Get(
-			fmt.Sprintf("ingestBudgets?next=%s", next),
+			fmt.Sprintf("v1/ingestBudgets?next=%s", next),
 		)
 		if err != nil {
 			return nil, err
@@ -123,7 +123,7 @@ func (s *Client) CollectorAssignedToIngestBudget(ingestBudgetId string, collecto
 
 	for {
 		body, _, err := s.Get(
-			fmt.Sprintf("ingestBudgets/%s/collectors?next=%s", ingestBudgetId, next),
+			fmt.Sprintf("v1/ingestBudgets/%s/collectors?next=%s", ingestBudgetId, next),
 		)
 		if err != nil {
 			return false, err
@@ -157,14 +157,14 @@ func (s *Client) CollectorAssignedToIngestBudget(ingestBudgetId string, collecto
 }
 
 func (s *Client) AssignCollectorToIngestBudget(ingestBudgetId string, collectorId int) error {
-	urlPath := fmt.Sprintf("ingestBudgets/%s/collectors/%d", ingestBudgetId, collectorId)
+	urlPath := fmt.Sprintf("v1/ingestBudgets/%s/collectors/%d", ingestBudgetId, collectorId)
 	_, err := s.Put(urlPath, nil)
 
 	return err
 }
 
 func (s *Client) UnAssignCollectorToIngestBudget(ingestBudgetId string, collectorId int) error {
-	_, err := s.Delete(fmt.Sprintf("ingestBudgets/%s/collectors/%d", ingestBudgetId, collectorId))
+	_, err := s.Delete(fmt.Sprintf("v1/ingestBudgets/%s/collectors/%d", ingestBudgetId, collectorId))
 
 	return err
 }

--- a/sumologic/sumologic_polling_source.go
+++ b/sumologic/sumologic_polling_source.go
@@ -47,7 +47,7 @@ func (s *Client) CreatePollingSource(source PollingSource, collectorID int) (int
 		Source: source,
 	}
 
-	urlPath := fmt.Sprintf("collectors/%d/sources", collectorID)
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources", collectorID)
 
 	body, err := s.Post(urlPath, request)
 
@@ -66,7 +66,7 @@ func (s *Client) CreatePollingSource(source PollingSource, collectorID int) (int
 }
 
 func (s *Client) GetPollingSource(collectorID, sourceID int) (*PollingSource, error) {
-	urlPath := fmt.Sprintf("collectors/%d/sources/%d", collectorID, sourceID)
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, sourceID)
 	body, _, err := s.Get(urlPath)
 
 	if err != nil {
@@ -92,7 +92,7 @@ func (s *Client) GetPollingSource(collectorID, sourceID int) (*PollingSource, er
 }
 
 func (s *Client) UpdatePollingSource(source PollingSource, collectorID int) error {
-	url := fmt.Sprintf("collectors/%d/sources/%d", collectorID, source.ID)
+	url := fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, source.ID)
 
 	type PollingSourceMessage struct {
 		Source PollingSource `json:"source"`

--- a/sumologic/sumologic_roles.go
+++ b/sumologic/sumologic_roles.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *Client) GetRole(id string) (*Role, error) {
-	data, _, err := s.Get(fmt.Sprintf("roles/%s", id))
+	data, _, err := s.Get(fmt.Sprintf("v1/roles/%s", id))
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +25,7 @@ func (s *Client) GetRole(id string) (*Role, error) {
 }
 
 func (s *Client) GetRoleName(name string) (*Role, error) {
-	data, _, err := s.Get("roles")
+	data, _, err := s.Get("v1/roles")
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (s *Client) GetRoleName(name string) (*Role, error) {
 }
 
 func (s *Client) DeleteRole(id string) error {
-	_, err := s.Delete(fmt.Sprintf("roles/%s", id))
+	_, err := s.Delete(fmt.Sprintf("v1/roles/%s", id))
 
 	return err
 }
@@ -59,7 +59,7 @@ func (s *Client) CreateRole(role Role) (string, error) {
 
 	var createdRole Role
 
-	responseBody, err := s.Post("roles", role)
+	responseBody, err := s.Post("v1/roles", role)
 	if err != nil {
 		return "", err
 	}
@@ -74,7 +74,7 @@ func (s *Client) CreateRole(role Role) (string, error) {
 }
 
 func (s *Client) UpdateRole(role Role) error {
-	url := fmt.Sprintf("roles/%s", role.ID)
+	url := fmt.Sprintf("v1/roles/%s", role.ID)
 
 	_, err := s.Put(url, role)
 

--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -288,7 +288,7 @@ func getFilters(d *schema.ResourceData) []Filter {
 
 func (s *Client) DestroySource(sourceID int, collectorID int) error {
 
-	_, err := s.Delete(fmt.Sprintf("collectors/%d/sources/%d", collectorID, sourceID))
+	_, err := s.Delete(fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, sourceID))
 
 	return err
 }
@@ -296,7 +296,7 @@ func (s *Client) DestroySource(sourceID int, collectorID int) error {
 func (s *Client) GetSourceName(collectorID int, sourceName string) (*Source, error) {
 
 	data, _, err := s.Get(
-		fmt.Sprintf("collectors/%d/sources", collectorID),
+		fmt.Sprintf("v1/collectors/%d/sources", collectorID),
 	)
 
 	if err != nil {

--- a/sumologic/sumologic_users.go
+++ b/sumologic/sumologic_users.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *Client) GetUser(id string) (*User, error) {
-	data, _, err := s.Get(fmt.Sprintf("users/%s", id))
+	data, _, err := s.Get(fmt.Sprintf("v1/users/%s", id))
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +25,7 @@ func (s *Client) GetUser(id string) (*User, error) {
 }
 
 func (s *Client) DeleteUser(id string) error {
-	_, err := s.Delete(fmt.Sprintf("users/%s", id))
+	_, err := s.Delete(fmt.Sprintf("v1/users/%s", id))
 
 	return err
 }
@@ -33,7 +33,7 @@ func (s *Client) DeleteUser(id string) error {
 func (s *Client) CreateUser(user User) (string, error) {
 	var createdUser User
 
-	responseBody, err := s.Post("users", user)
+	responseBody, err := s.Post("v1/users", user)
 	if err != nil {
 		return "", err
 	}
@@ -48,7 +48,7 @@ func (s *Client) CreateUser(user User) (string, error) {
 }
 
 func (s *Client) UpdateUser(user User) error {
-	url := fmt.Sprintf("users/%s", user.ID)
+	url := fmt.Sprintf("v1/users/%s", user.ID)
 
 	user.ID = ""
 	user.Email = ""


### PR DESCRIPTION
Adding folder management plugin for terraform provider. Tested using acceptance tests and folder CRUD on production deployment.

Used these references for CRUD operations:
Create: https://nite-api.sumologic.net/docs/#operation/createFolder
Read: https://nite-api.sumologic.net/docs/#operation/getFolder
Update: https://nite-api.sumologic.net/docs/#operation/updateFolder
Delete: https://nite-api.sumologic.net/docs/#operation/beginAsyncDelete, https://nite-api.sumologic.net/docs/#operation/getAsyncDeleteStatus

As folder management is V2 (not V1), I updated the URLs in sumologic_client.go and request paths extensions in the respective files.

@frankreno 