### PR TITLE
Fixing the import warning

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/sumologic/sumologic-terraform-provider/sumologic"
+	"github.com/SumoLogic/sumologic-terraform-provider/sumologic"
 )
 
 func main() {


### PR DESCRIPTION
Getting rid of the following warning on `make install`:
```
can't load package: package github.com/SumoLogic/sumologic-terraform-provider/sumologic: case-insensitive import collision: "github.com/SumoLogic/sumologic-terraform-provider/sumologic" and "github.com/sumologic/sumologic-terraform-provider/sumologic"
mkdir -p dist/darwin_amd64; \
        go build -o dist/darwin_amd64/terraform-provider-sumologic
[...]
```

Not sure if anyone else sees it (could it be Mac-specific as Mac handles some things case insensitive?)