### PR TITLE
BaseURL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ $ terraform plan
 - `access_id` - (Optional) This is the Sumo Logic Access ID. It must be provided, but it can also be sourced from the SUMOLOGIC_ACCESSID environment variable.
 - `access_key` - (Optional) This is the Sumo Logic Access Key. It must be provided, but it can also be sourced from the SUMOLOGIC_ACCESSKEY environment variable.
 - `environment` - (Optional) This is the API endpoint to use. Default is us2, but it can also be sourced from the SUMOLOGIC_ENVIRONMENT environment variable. See the [Sumo Logic documentation][1] for details on which environment you should use.
+- `base_url` - (Optional) This is the API endpoint base URL to use. You can specify that instead of the environment. It can also be sourced from SUMOLOGIC_BASE_URL environment variable.
 
 # Building the provider
 

--- a/docs/sumologic-provider.md
+++ b/docs/sumologic-provider.md
@@ -69,6 +69,7 @@ $ terraform plan
 - `access_id` - (Optional) This is the Sumo Logic Access ID. It must be provided, but it can also be source from the SUMOLOGIC_ACCESSID environment variable.
 - `access_key` - (Optional) This is the Sumo Logic Access Key. It must be provided, but it can also be sourced from the SUMOLOGIC_ACCESSKEY variable.
 - `environment` - (Optional) This is the API endpoint to use. Default is `us2`. See the [Sumo Logic documentation][1] for details on which environment you should use. This value can also be source from the SUMOLOGIC_ENVIRONMENT variable.
+- `base_url` - (Optional) This is the API endpoint base URL to use. You can specify that instead of the environment. It can also be sourced from SUMOLOGIC_BASE_URL environment variable.
 
 [Back to Index][0]
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sumologic/sumologic-terraform-provider
+module github.com/SumoLogic/sumologic-terraform-provider
 
 go 1.12
 
@@ -6,5 +6,4 @@ require (
 	github.com/go-errors/errors v1.0.1
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce // indirect
 	github.com/hashicorp/terraform v0.12.0
-	github.com/sumologic/sumologic-terraform-provider v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/Azure/go-autorest v10.15.4+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxS
 github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
+github.com/SumoLogic/sumologic-terraform-provider v1.0.0 h1:CegxU9WKxxtsPeWFlZ2twPSu94f1xsyDw/9qF3NV88k=
+github.com/SumoLogic/sumologic-terraform-provider v1.0.0/go.mod h1:YVcJt8g/csOAh57+3UXBBD1IiG+AMQqIdX7NgPLhwd0=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -28,6 +28,11 @@ func Provider() terraform.ResourceProvider {
 				Optional: true,
 				Default:  os.Getenv("SUMOLOGIC_ENVIRONMENT"),
 			},
+			"base_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  os.Getenv("SUMOLOGIC_BASE_URL"),
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"sumologic_collector":                          resourceSumologicCollector(),
@@ -38,7 +43,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_user":                               resourceSumologicUser(),
 			"sumologic_ingest_budget":                      resourceSumologicIngestBudget(),
 			"sumologic_collector_ingest_budget_assignment": resourceSumologicCollectorIngestBudgetAssignment(),
-			"sumologic_folder":				resourceSumologicFolder(),
+			"sumologic_folder":                             resourceSumologicFolder(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"sumologic_caller_identity": dataSourceSumologicCallerIdentity(),
@@ -54,6 +59,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	accessId := d.Get("access_id").(string)
 	accessKey := d.Get("access_key").(string)
 	environment := d.Get("environment").(string)
+	baseUrl := d.Get("base_url").(string)
 
 	msg := ""
 	if accessId == "" {
@@ -73,5 +79,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		accessId,
 		accessKey,
 		environment,
+		baseUrl,
 	)
 }

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -214,14 +214,17 @@ func (s *Client) Delete(urlPath string) ([]byte, error) {
 	return d, nil
 }
 
-func NewClient(accessID, accessKey, environment string) (*Client, error) {
+func NewClient(accessID, accessKey, environment, base_url string) (*Client, error) {
 	client := Client{
 		AccessID:    accessID,
 		AccessKey:   accessKey,
-		Environment: environment,
 		httpClient:  http.DefaultClient,
+		Environment: environment,
 	}
+	if base_url == "" {
+	  base_url = endpoints[client.Environment]
+	}
+	client.BaseURL, _ = url.Parse(base_url)
 
-	client.BaseURL, _ = url.Parse(endpoints[client.Environment])
 	return &client, nil
 }


### PR DESCRIPTION
Adding the ability to provide explicitly the baseURL (the API URL) if none of the built-in ones provided by Sumo Logic is what we what to interface against.

