### PR TITLE
Upgrading to Go 1.13 to fix Apache git issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.12"
+  - "1.13"
 
 env:
   global:


### PR DESCRIPTION
# Problem
Our TravisCI builds recently fail with:
```
go: git.apache.org/thrift.git@v0.0.0-20180902110319-2566ecd5d999: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /home/travis/gopath/pkg/mod/cache/vcs/83dba939f95a790e497d565fc4418400145a1a514f955fa052f662d56e920c3e: exit status 128:
	fatal: unable to access 'https://git.apache.org/thrift.git/': Failed to connect to git.apache.org port 443: Connection timed out
go: error loading module requirements
```
# Context
See
https://github.com/articulate/terraform-provider-okta/issues/267
or
https://github.com/hashicorp/terraform/issues/22664

# Solution
Upgrade to Go 1.13. It helped the Okta provider.