### PR TITLE
Add collector import by name functionality

### DIFF
--- a/docs/r/sumologic_collector.md
+++ b/docs/r/sumologic_collector.md
@@ -28,8 +28,15 @@ The following attributes are exported:
 
 ## Import
 Collectors can be imported using the collector id, e.g.:
+
 ```hcl
 terraform import sumologic_collector.test 1234567890
+```
+
+Collectors can also be imported using the collector name, which is unique per Sumo Logic account, e.g.:
+
+```hcl
+terraform import sumologic_collector.test my_test_collector
 ```
 
 [Back to Index][0]

--- a/docs/r/sumologic_http_source.md
+++ b/docs/r/sumologic_http_source.md
@@ -34,6 +34,12 @@ HTTP sources can be imported using the collector and source IDs (`collector/sour
 terraform import sumologic_http_source.test 123/456
 ```
 
++HTTP sources can be imported using the collector name and source name (`collectorName/sourceName`), e.g.:
+
+```hcl
+terraform import sumologic_http_source.test my-test-collector/my-test-source
+```
+
 [Back to Index][0]
 
 [0]: ../README.md

--- a/sumologic/resource_sumologic_collector.go
+++ b/sumologic/resource_sumologic_collector.go
@@ -156,11 +156,11 @@ func resourceSumologicCollectorExists(d *schema.ResourceData, meta interface{}) 
 
 	if err != nil {
 		_, err := c.GetCollectorName(d.Id())
-		return err == nil, nil
+		return err == nil, err
 	}
 
 	_, err = c.GetCollector(id)
-	return err == nil, nil
+	return err == nil, err
 }
 
 func resourceToCollector(d *schema.ResourceData) Collector {

--- a/sumologic/resource_sumologic_collector.go
+++ b/sumologic/resource_sumologic_collector.go
@@ -1,7 +1,6 @@
 package sumologic
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 
@@ -70,14 +69,12 @@ func resourceSumologicCollectorRead(d *schema.ResourceData, meta interface{}) er
 
 	id, err := strconv.Atoi(d.Id())
 
+	var collector *Collector
 	if err != nil {
-		return err
-	}
-
-	collector, err := c.GetCollector(id)
-
-	if err != nil {
-		return err
+		collector, _ = c.GetCollectorName(d.Id())
+		d.SetId(strconv.Itoa(collector.ID))
+	} else {
+		collector, _ = c.GetCollector(id)
 	}
 
 	if collector == nil {
@@ -158,11 +155,11 @@ func resourceSumologicCollectorExists(d *schema.ResourceData, meta interface{}) 
 	id, err := strconv.Atoi(d.Id())
 
 	if err != nil {
-		return false, fmt.Errorf("collector id should be an integer; got %s (%s)", d.Id(), err)
+		_, err := c.GetCollectorName(d.Id())
+		return err == nil, nil
 	}
 
 	_, err = c.GetCollector(id)
-
 	return err == nil, nil
 }
 

--- a/sumologic/sumologic_collectors.go
+++ b/sumologic/sumologic_collectors.go
@@ -31,7 +31,7 @@ func (s *Client) GetCollectorName(name string) (*Collector, error) {
 	}
 
 	if data == nil {
-		return &Collector{}, nil
+		return nil, fmt.Errorf("collector with name '%s' does not exist", name)
 	}
 
 	var response CollectorResponse

--- a/sumologic/sumologic_collectors.go
+++ b/sumologic/sumologic_collectors.go
@@ -25,8 +25,7 @@ func (s *Client) GetCollector(id int) (*Collector, error) {
 }
 
 func (s *Client) GetCollectorName(name string) (*Collector, error) {
-	// TODO: check default limit count of 1000 and paginate
-	data, _, err := s.Get("v1/collectors")
+	data, _, err := s.Get(fmt.Sprintf("v1/collectors/name/%s", name))
 	if err != nil {
 		return nil, err
 	}
@@ -35,19 +34,13 @@ func (s *Client) GetCollectorName(name string) (*Collector, error) {
 		return &Collector{}, nil
 	}
 
-	var response CollectorList
+	var response CollectorResponse
 	err = json.Unmarshal(data, &response)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, c := range response.Collectors {
-		if c.Name == name {
-			return &c, nil
-		}
-	}
-
-	return nil, nil
+	return &response.Collector, nil
 }
 
 func (s *Client) DeleteCollector(id int) error {


### PR DESCRIPTION
This PR adds the ability to `terraform import` collectors by `name` and sources by `collectorName/sourceName`.  We will use this in the future for our Kubernetes offering in https://github.com/SumoLogic/sumologic-kubernetes-collection

It also switches to the new API to get a collector by name, rather than iterating through all collectors.

Test plan:
1. Create collector with http source using `terraform apply`:
```
provider "sumologic" { }
resource "sumologic_collector" "c1" {
    name = "rmiller-test-hosted"
}
resource "sumologic_http_source" "h1" {
    name = "rmiller-test-http_rename"
    category = "test_cat"
    collector_id = "${sumologic_collector.c1.id}"
}
```
2. Delete `terraform.tfstate*` files
3. `terraform import sumologic_collector.c1 rmiller-test-hosted`
4. `import sumologic_http_source.h1 rmiller-test-hosted/rmiller-test-http_rename`

Then tried updating a few fields in the terraform file and `tf apply`.

FYI: @lei-sumo 