### PR TITLE
Don't recreate source on name/fields change

### DIFF
--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -53,7 +53,7 @@ func resourceSumologicSource() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
+				ForceNew: false,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -167,7 +167,7 @@ func resourceSumologicSource() *schema.Resource {
 			"fields": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 				Default:  nil,
 			},
 			"collector_id": {


### PR DESCRIPTION
Noticed a bug while working on https://github.com/SumoLogic/sumologic-terraform-provider/pull/76 where importing a source and then changing its name causes a 2nd source to be created in Sumo. Frank realized it was due to this `ForceNew` logic which re-creates the resource (delete + create) but we simply want to update the source, not recreate it for modifiable fields like `name` and `fields`. I have left it recreating the source for "non-modifiable" fields like `cutoff_relative_time` and `collector_id`.

Test plan:
1. Create collector with http source using `terraform apply`:
```
provider "sumologic" { }
resource "sumologic_collector" "c1" {
    name = "rmiller-test-hosted"
}
resource "sumologic_http_source" "h1" {
    name = "rmiller-test-http_rename"
    category = "test_cat"
    collector_id = "${sumologic_collector.c1.id}"
}
```
2. Delete `terraform.tfstate*` files
3. `terraform import sumologic_collector.c1 rmiller-test-hosted`
4. `terraform import sumologic_http_source.h1 rmiller-test-hosted/rmiller-test-http_rename`
5. Update h1 name to "rmiller-test-http_rename2"
6. `terraform apply`

Observe same source has updated name in Sumo UI.

7. Add fields
8. `terraform apply`
9. Update fields with new key-values
10. `terraform apply`

Observe same source has updated fields in Sumo UI