### PR TITLE
Fix source import for missing collector/source

### DIFF
--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -220,9 +220,17 @@ func resourceSumologicSourceImport(d *schema.ResourceData, m interface{}) ([]*sc
 	} else {
 		// collectorName/sourceName
 		collector, _ := c.GetCollectorName(ids[0])
-		source, _ := c.GetSourceName(collector.ID, ids[1])
-		d.SetId(strconv.Itoa(source.ID))
-		d.Set("collector_id", collector.ID)
+		if collector != nil {
+			source, _ := c.GetSourceName(collector.ID, ids[1])
+			if source != nil {
+				d.SetId(strconv.Itoa(source.ID))
+				d.Set("collector_id", collector.ID)
+			} else {
+				return nil, fmt.Errorf("source with name '%s' does not exist", ids[1])
+			}
+		} else {
+			return nil, fmt.Errorf("collector with name '%s' does not exist", ids[0])
+		}
 	}
 
 	return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
This fixes a bug that caused TF to crash if you try to import a source with an invalid collector name, or a valid collector name and invalid source name.  Now it will error gracefully with an error message:

```
terraform $ tf import sumologic_http_source.h1 "not-a-real-collector/not-a-real-source"
sumologic_http_source.h1: Importing from ID "not-a-real-collector/not-a-real-source"...

Error: collector with name 'not-a-real-collector' does not exist
```
```
terraform $ tf import sumologic_http_source.h1 "rmiller-test-hosted/not-a-real-source"
sumologic_http_source.h1: Importing from ID "rmiller-test-hosted/not-a-real-source"...

Error: source with name 'not-a-real-source' does not exist
```