### PR TITLE
Update sumologic-provider.md

### DIFF
--- a/docs/sumologic-provider.md
+++ b/docs/sumologic-provider.md
@@ -61,7 +61,7 @@ provider "sumologic" { }
 
 ```bash
 $ export SUMOLOGIC_ACCESSID="your-access-id"
-$ export SUMOLOGIC_ACCESSKEY="your-access-id"
+$ export SUMOLOGIC_ACCESSKEY="your-access-key"
 $ terraform plan
 ```
 


### PR DESCRIPTION
`SUMOLOGIC_ACCESSKEY` should reference "your-access-key" instead like the other examples above:

```hcl
provider "sumologic" {
    environment = "us2"
    access_id   = "your-access-id"
    access_key  = "your-access-key"
}
```