### PR TITLE
polling: document "url" attribute (for SNS)

### DIFF
--- a/docs/r/sumologic_polling_source.md
+++ b/docs/r/sumologic_polling_source.md
@@ -56,6 +56,7 @@ In addition to the common properties, the following arguments are supported:
 
 ## Attributes reference
 - `id` - The internal ID of the source.
+- `url` - The HTTP endpoint to use with [SNS to notify Sumo Logic of new files](https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-S3-Source#Set_up_SNS_in_AWS_(Optional)).
 
 [Back to Index][0]
 


### PR DESCRIPTION
`url` is supported by the schema of `polling_source`:

https://github.com/SumoLogic/sumologic-terraform-provider/blob/master/sumologic/resource_sumologic_polling_source.go#L33-L38

This URL is needed to if you want to configure S3 to notify SNS of new objects and then SNS to notify Sumo Logic via HTTP.

The `url` attribute for a polling source would be passed to a `aws_sns_topic_subscription` resource.