### PR TITLE
fix errors from the golangcli-lint

### DIFF
--- a/sumologic/resource_sumologic_content_test.go
+++ b/sumologic/resource_sumologic_content_test.go
@@ -1,11 +1,9 @@
 package sumologic
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -94,20 +92,6 @@ func testAccCheckContentAttributes(name string) resource.TestCheckFunc {
 			resource.TestCheckResourceAttrSet(name, "parent_id"),
 		)
 		return f(s)
-	}
-}
-
-func testAccCheckContentConfig(content *Content) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		var expectedContent Content
-		//unmarshal the expected config for comparison. Ignore the error here, configuration is known
-		_ = json.Unmarshal([]byte(configJson), &expectedContent)
-
-		//if the configuration structs are not equal
-		if !reflect.DeepEqual(expectedContent, content) {
-			return fmt.Errorf("Configuration is not equal, %v does not match expected %v", content, expectedContent)
-		}
-		return nil
 	}
 }
 

--- a/sumologic/resource_sumologic_extraction_rule.go
+++ b/sumologic/resource_sumologic_extraction_rule.go
@@ -112,17 +112,6 @@ func resourceSumologicFieldExtractionRuleUpdate(d *schema.ResourceData, meta int
 	return resourceSumologicFieldExtractionRuleRead(d, meta)
 }
 
-func resourceSumologicFieldExtractionRuleExists(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-
-	_, err := c.GetFieldExtractionRule(d.Id())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func resourceToFieldExtractionRule(d *schema.ResourceData) FieldExtractionRule {
 
 	return FieldExtractionRule{

--- a/sumologic/resource_sumologic_role.go
+++ b/sumologic/resource_sumologic_role.go
@@ -119,17 +119,6 @@ func resourceSumologicRoleUpdate(d *schema.ResourceData, meta interface{}) error
 	return resourceSumologicRoleRead(d, meta)
 }
 
-func resourceSumologicRoleExists(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-
-	_, err := c.GetRole(d.Id())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func resourceToRole(d *schema.ResourceData) Role {
 	rawCapabilities := d.Get("capabilities").([]interface{})
 	capabilities := make([]string, len(rawCapabilities))

--- a/sumologic/resource_sumologic_user.go
+++ b/sumologic/resource_sumologic_user.go
@@ -121,17 +121,6 @@ func resourceSumologicUserUpdate(d *schema.ResourceData, meta interface{}) error
 	return resourceSumologicUserRead(d, meta)
 }
 
-func resourceSumologicUserExists(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-
-	_, err := c.GetUser(d.Id())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func resourceToUser(d *schema.ResourceData) User {
 	rawRoleIds := d.Get("role_ids").([]interface{})
 	roleIds := make([]string, len(rawRoleIds))

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -34,7 +34,7 @@ var endpoints = map[string]string{
 	"ca":  "https://api.ca.sumologic.com/api/",
 }
 
-var rateLimiter = time.Tick(time.Minute / 240)
+var rateLimiter = time.NewTicker(time.Minute / 240)
 
 func createNewRequest(method, url string, body io.Reader, accessID string, accessKey string) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, body)
@@ -65,7 +65,7 @@ func (s *Client) PostWithCookies(urlPath string, payload interface{}) ([]byte, [
 		return nil, nil, err
 	}
 
-	<-rateLimiter
+	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, nil, err
@@ -103,7 +103,7 @@ func (s *Client) GetWithCookies(urlPath string, cookies []*http.Cookie) ([]byte,
 		req.AddCookie(cookie)
 	}
 
-	<-rateLimiter
+	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, "", err
@@ -134,7 +134,7 @@ func (s *Client) Post(urlPath string, payload interface{}) ([]byte, error) {
 		return nil, err
 	}
 
-	<-rateLimiter
+	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -161,7 +161,7 @@ func (s *Client) PostRawPayload(urlPath string, payload string) ([]byte, error) 
 		return nil, err
 	}
 
-	<-rateLimiter
+	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
 
 	if err != nil {
@@ -193,7 +193,7 @@ func (s *Client) Put(urlPath string, payload interface{}) ([]byte, error) {
 	}
 	req.Header.Add("If-Match", etag)
 
-	<-rateLimiter
+	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -221,7 +221,7 @@ func (s *Client) Get(urlPath string) ([]byte, string, error) {
 		return nil, "", err
 	}
 
-	<-rateLimiter
+	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, "", err
@@ -251,7 +251,7 @@ func (s *Client) Delete(urlPath string) ([]byte, error) {
 		return nil, err
 	}
 
-	<-rateLimiter
+	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The makefile has the command `make lint`
Fixed the non collector errors from this. 

- Mainly removing unused functions
- not using wrapper function for time `tick` as it leaks and is not cleaned up by garbage collector

Plan is to add this linter as one of the tasks on our travis build so that we do not add bad code moving forward. 

The terraform linter will be added as a github action unless we can also add that to the travis build. 