### PR TITLE
update README.md with new golang version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 ------------
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.11.x or 0.12.x
-- [Go](https://golang.org/doc/install) >= 1.9 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) >= 1.13 (to build the provider plugin)
 - [Sumo Logic](https://www.sumologic.com/pricing/)
 
 # Using the provider


### PR DESCRIPTION
Was getting 
```
# github.com/hashicorp/go-getter
../../go/pkg/mod/github.com/hashicorp/go-getter@v1.4.1/get_http.go:91:24: g.Header.Clone undefined (type http.Header has no field or method Clone)
../../go/pkg/mod/github.com/hashicorp/go-getter@v1.4.1/get_http.go:172:24: g.Header.Clone undefined (type http.Header has no field or method Clone)
make: *** [install] Error 2
```
with go 1.11

this function is added in go 1.13
https://golang.org/pkg/net/http/#Header.Clone